### PR TITLE
fix: README.md typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ can definitely be improved, especially on the passing data between the UI, Quark
 
     git clone https://github.com/temporalio/docker-compose.git
     cd  docker-compose
-    docker-compose -f docker-compose-cas-es.yml up
+    docker-compose -f docker-compose-cass-es.yml up
 
 ### 2. Start the demo app (Quarkus dev mode)
 


### PR DESCRIPTION
Changed docker-compose -f docker-compose-cas-es.yml up --> docker-compose -f docker-compose-cass-es.yml up

<img width="350" alt="Screenshot 2023-05-25 at 1 07 57 PM" src="https://github.com/tsurdilo/swtemporal/assets/52350067/b1eeb23a-8c70-43a0-a781-b57103e2cf10">
